### PR TITLE
feat: adding seo component to page collection type

### DIFF
--- a/backend/src/api/page/content-types/page/schema.json
+++ b/backend/src/api/page/content-types/page/schema.json
@@ -9,8 +9,6 @@
     "description": ""
   },
   "options": {
-    "increments": true,
-    "timestamps": true,
     "draftAndPublish": true
   },
   "pluginOptions": {
@@ -27,16 +25,15 @@
         }
       }
     },
-    "metadata": {
+    "seo": {
       "type": "component",
       "repeatable": false,
-      "component": "meta.metadata",
-      "required": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "component": "shared.seo"
     },
     "contentSections": {
       "type": "dynamiczone",

--- a/backend/src/api/page/middlewares/page-populate-middleware.js
+++ b/backend/src/api/page/middlewares/page-populate-middleware.js
@@ -5,6 +5,9 @@
  */
 
 const populate = {
+  seo: {
+    populate: "*"
+  },
   contentSections: {
     populate: {
       picture: {
@@ -38,12 +41,12 @@ const populate = {
   },
 };
 
-module.exports = (config, { strapi }) => {
+module.exports = (config, {strapi}) => {
   // Add your own logic here.
   return async (ctx, next) => {
     ctx.query = {
       populate,
-      filters: { slug: ctx.query.filters.slug },
+      filters: {slug: ctx.query.filters.slug},
       locale: ctx.query.locale,
     };
 

--- a/frontend/src/app/[lang]/[...slug]/page.tsx
+++ b/frontend/src/app/[lang]/[...slug]/page.tsx
@@ -14,8 +14,8 @@ type Props = {
 
 export async function generateMetadata({params}: Props): Promise<Metadata> {
     const page = await getPageBySlug(params.slug, params.lang);
-    if (!page.data[0].attributes.metadata) return FALLBACK_SEO;
-    const metadata = page.data[0].attributes.metadata
+    if (!page.data[0].attributes.seo) return FALLBACK_SEO;
+    const metadata = page.data[0].attributes.seo
 
     return {
         title: metadata.metaTitle,


### PR DESCRIPTION
This is only a first draft to fix [issue](https://github.com/strapi/nextjs-corporate-starter/issues/32), feedback is highly appreciated.

Known problems:

- Metadata for the homepage is using the values from global, preferred would be if fallback > global > page based seo