### PR TITLE
fix: category page | set link to post to be relative

### DIFF
--- a/frontend/src/app/[lang]/views/blog-list.tsx
+++ b/frontend/src/app/[lang]/views/blog-list.tsx
@@ -67,7 +67,7 @@ export default function PostList({
 
           return (
             <Link
-              href={`blog/${category?.slug}/${article.attributes.slug}`}
+              href={`/blog/${category?.slug}/${article.attributes.slug}`}
               key={article.id}
               className="max-w-sm mx-auto group hover:no-underline focus:no-underline dark:bg-gray-900 lg:w-[300px] xl:min-w-[375px] rounded-2xl overflow-hidden shadow-lg"
             >


### PR DESCRIPTION
In some instances, on the category page, the link will render as
blog/blog/{slug} due to the link not being relative.

This will cause a bunch of random errors that are hard to debug.
(i.e., no meta/SEO attributes found).
