### PR TITLE
Issue #15: Display localized content in Navbar and Footer

### DIFF
--- a/frontend/src/app/[lang]/layout.tsx
+++ b/frontend/src/app/[lang]/layout.tsx
@@ -10,7 +10,7 @@ import Navbar from "./components/Navbar";
 import {FALLBACK_SEO} from "@/app/[lang]/utils/constants";
 
 
-async function getGlobal(): Promise<any> {
+async function getGlobal(lang: string): Promise<any> {
   const token = process.env.NEXT_PUBLIC_STRAPI_API_TOKEN;
 
   if (!token) throw new Error("The Strapi API Token environment variable is not set.");
@@ -31,12 +31,13 @@ async function getGlobal(): Promise<any> {
       "footer.socialLinks",
       "footer.categories",
     ],
+    locale: lang,
   };
   return await fetchAPI(path, urlParamsObject, options);
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const meta = await getGlobal();
+export async function generateMetadata({ params } : { params: {lang: string}}): Promise<Metadata> {
+  const meta = await getGlobal(params.lang);
 
   if (!meta.data) return FALLBACK_SEO;
 
@@ -59,7 +60,7 @@ export default async function RootLayout({
   children: React.ReactNode;
   params: { lang: string };
 }) {
-  const global = await getGlobal();
+  const global = await getGlobal(params.lang);
   // TODO: CREATE A CUSTOM ERROR PAGE
   if (!global.data) return null;
   


### PR DESCRIPTION
Issue  #15:
Navbar and Footer components in Next.js are not displaying localized content fetched from the Strapi CMS. The default locale content is being shown instead of the expected localized content.

Fix:
Refactored the RootLayout component to support localization. The getGlobal function now accepts the lang parameter and fetches the appropriate data based on the selected language. The generateMetadata function receives the params object as a parameter, allowing it to retrieve the metadata for the specified language. These changes ensure that the Navbar and Footer components display the correct localized content.