### PR TITLE
Fix category slug generation to reflect category name

### DIFF
--- a/backend/src/api/category/content-types/category/schema.json
+++ b/backend/src/api/category/content-types/category/schema.json
@@ -16,7 +16,8 @@
       "type": "string"
     },
     "slug": {
-      "type": "uid"
+      "type": "uid",
+      "targetField": "name"
     },
     "articles": {
       "type": "relation",


### PR DESCRIPTION
This pull request addresses the issue #64 where the category slug generated was always set to "category" regardless of the actual category name. The commit introduces changes to the category's schema configuration to ensure that the slug is based on the category's name.