### PR TITLE
front-end: Add populate parameters to article API query

### DIFF
--- a/frontend/src/app/[lang]/blog/[category]/[slug]/page.tsx
+++ b/frontend/src/app/[lang]/blog/[category]/[slug]/page.tsx
@@ -15,6 +15,7 @@ async function getPostBySlug(slug: string) {
                 populate: {
                     '__component': '*', 
                     'files': '*',
+                    'file': '*',
                     'url': '*',
                     'body': '*',
                     'title': '*',

--- a/frontend/src/app/[lang]/blog/[category]/[slug]/page.tsx
+++ b/frontend/src/app/[lang]/blog/[category]/[slug]/page.tsx
@@ -11,7 +11,16 @@ async function getPostBySlug(slug: string) {
             cover: { fields: ['url'] },
             authorsBio: { populate: '*' },
             category: { fields: ['name'] },
-            blocks: { populate: '*' },
+            blocks: { 
+                populate: {
+                    '__component': '*', 
+                    'files': '*',
+                    'url': '*',
+                    'body': '*',
+                    'title': '*',
+                    'author': '*',
+                }
+            },
         },
     };
     const options = { headers: { Authorization: `Bearer ${token}` } };


### PR DESCRIPTION
Dynamic zone components (such as a slider) are not displaying on the article page as they are supposed to. This has been fixed by adding populate parameters for blocks (DZ) field to the article query.