### PR TITLE
Add prompt in console for missing token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 readme-images
 .vscode
 .DS_Store
+**/.yarn

--- a/frontend/src/app/[lang]/page.tsx
+++ b/frontend/src/app/[lang]/page.tsx
@@ -4,9 +4,20 @@ import {getPageBySlug} from "@/app/[lang]/utils/get-page-by-slug";
 
 
 export default async function RootRoute({params}: { params: { lang: string } }) {
-    const page = await getPageBySlug('home', params.lang);
-    if (page.data.length == 0 && params.lang !== "en") return <LangRedirect/>
-    if (page.data.length === 0) return null;
-    const contentSections = page.data[0].attributes.contentSections;
-    return contentSections.map((section: any, index: number) => sectionRenderer(section, index));
+    try {
+      const page = await getPageBySlug('home', params.lang)
+      if (page.error && page.error.status == 401)
+        throw new Error(
+          'Missing or invalid credentials. Have you created an access token using the Strapi admin panel? http://localhost:1337/admin/'
+        )
+
+      if (page.data.length == 0 && params.lang !== 'en') return <LangRedirect />
+      if (page.data.length === 0) return null
+      const contentSections = page.data[0].attributes.contentSections
+      return contentSections.map((section: any, index: number) =>
+        sectionRenderer(section, index)
+      )
+    } catch (error: any) {
+      window.alert('Missing or invalid credentials')
+    }
 }


### PR DESCRIPTION
## Includes
- [x] Add a prompt in the console for users who don't read documentation thoroughly

## Nice to have
New to NextJS and tried to implement these but they didn't work. Thought I'd note as an idea.

- [ ] Prompt in frontend/JS console
- [ ] Alert in in the browser UI

