### PR TITLE
correct sqlite version to fix install failure

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "@strapi/plugin-seo": "^1.8.0",
     "@strapi/plugin-users-permissions": "4.12.5",
     "@strapi/strapi": "4.12.5",
-    "better-sqlite3": "8.4.0"
+    "better-sqlite3": "8.7.0"
   },
   "author": {
     "name": "A Strapi developer"


### PR DESCRIPTION
Get following error while yarn install the backend dependencies, upgrade the version of better-sqllit3 to the v8 latest subversion then get it resolved.

```
error /Users/andre/Download/nextjs-corporate-starter/backend/node_modules/better-sqlite3: Command failed.
Exit code: 127
Command: prebuild-install || node-gyp rebuild --release
```