### PR TITLE
Update tsconfig.json to use @ alias in PHP/Webstorm IDE

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,7 @@
         "name": "next"
       }
     ],
+    "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Without baseUrl setup, PHP/Webstorm IDE don't recognize @ alias. IDE functionalities like "Go to Declaration" or "Methods search" cannot be used.