### PR TITLE
fix: add safe check for seo.attributes and defaultLocale fallback

### DIFF
--- a/frontend/src/app/[lang]/[...slug]/page.tsx
+++ b/frontend/src/app/[lang]/[...slug]/page.tsx
@@ -15,7 +15,7 @@ type Props = {
 export async function generateMetadata({params}: Props): Promise<Metadata> {
     const page = await getPageBySlug(params.slug, params.lang);
 
-    if (!page.data[0].attributes?.seo) return FALLBACK_SEO;
+    if (!page.data[0]?.attributes?.seo) return FALLBACK_SEO;
     const metadata = page.data[0].attributes.seo
 
     return {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -15,7 +15,12 @@ function getLocale(request: NextRequest): string | undefined {
     let languages = new Negotiator({ headers: negotiatorHeaders }).languages();
     // @ts-ignore locales are readonly
     const locales: string[] = i18n.locales;
-    return matchLocale(languages, locales, i18n.defaultLocale);
+    try {
+        return matchLocale(languages, locales, i18n.defaultLocale);
+      } catch (e) {
+        // Invalid accept-language header
+        return i18n.defaultLocale;
+      }
 }
 
 export function middleware(request: NextRequest) {


### PR DESCRIPTION
This fixes an error that I was seeing when deploying to Render.

`RangeError: Incorrect locale information provided`

I hope this helps some other people!